### PR TITLE
Allow nested paths for gateway routes

### DIFF
--- a/api-gateway/src/main/resources/application.properties
+++ b/api-gateway/src/main/resources/application.properties
@@ -12,8 +12,8 @@ logging.level.org.springframework.cloud.gateway=TRACE
 
 spring.cloud.gateway.routes[0].id=product-service
 spring.cloud.gateway.routes[0].uri=lb://product-service
-spring.cloud.gateway.routes[0].predicates[0]=Path=/api/product
+spring.cloud.gateway.routes[0].predicates[0]=Path=/api/product/**
 
 spring.cloud.gateway.routes[1].id=order-service
 spring.cloud.gateway.routes[1].uri=lb://order-service
-spring.cloud.gateway.routes[1].predicates[0]=Path=/api/order
+spring.cloud.gateway.routes[1].predicates[0]=Path=/api/order/**


### PR DESCRIPTION
## Summary
- forward nested `/api/product/**` and `/api/order/**` requests through the API gateway

## Testing
- `mvn -q -pl api-gateway test` *(fails: Non-resolvable parent POM; Network is unreachable)*
- `mvn -q -pl api-gateway package` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6890a3b9198c83238841d4c92a5b9a8a